### PR TITLE
move includes on top of css declarations

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Aldryn Boilerplate Standard
 ===========================
 
+3.0.6
+-----
+- update to css rule order guidelines
+
 3.0.5
 -----
 - added IIFE for js code in order to maintain 'use strict'

--- a/docs/css/guidelines.rst
+++ b/docs/css/guidelines.rst
@@ -23,12 +23,12 @@ Style
 
 Use block-style and group elements underneath:
 
+#. includes (compass includes)
 #. extending
 #. visibility, position
 #. color, font-size, line-height, font-* (font relevant data)
 #. width, height, padding, margin (box model relevant date)
 #. border, background (box style data)
-#. includes (compass includes)
 #. media, print (media queries)
 #. :after, :before, :active (pseudo elements)
 

--- a/docs/css/guidelines.rst
+++ b/docs/css/guidelines.rst
@@ -43,6 +43,9 @@ Example
 .. code-block:: css
 
     .addon-blog {
+        // mixins
+        @include border-radius(3px);
+        @include box-shadow(0 0 2px #eee);
         // extending
         @extend .list-unstyled;
         // styles
@@ -58,9 +61,6 @@ Example
         margin: 0 auto;
         border: 2px solid #ccc;
         background: #ddd;
-        // mixins
-        @include border-radius(3px);
-        @include box-shadow(0 0 2px #eee);
         // desktop and up
         @media (min-width: $screen-md-min) {
             display: block;


### PR DESCRIPTION
Reasoning: sometimes we need to use non-trivial mixins, like bootstrap ones, and we also need to override some properties defined in that mixin. Putting `@include` declarations on top allows that.