### PR TITLE
Release 3.0.6

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ Aldryn Boilerplate Standard
 -----
 - update to css rule order guidelines
 - stubbing full console api instead of just console.log now in unsupporting browsers
+- fixed an issue where docs did not get rendered anymore on rtfd.org
 
 3.0.5
 -----

--- a/boilerplate.json
+++ b/boilerplate.json
@@ -1,7 +1,7 @@
 {
     "name": "Aldryn Bootstrap Boilerplate",
     "description": "Advanced Django CMS Boilerplate based on Bootstrap",
-    "version": "3.0.5",
+    "version": "3.0.6",
     "url": "https://github.com/divio",
     "templates": [
         ["fullwidth.html", "full width"],


### PR DESCRIPTION
- update to css rule order guidelines
- stubbing full console api instead of just console.log now in unsupporting browsers
- fixed an issue where docs did not get rendered anymore on rtfd.org