### PR TITLE
added maximumLineLength for jscs

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -1,6 +1,11 @@
 {
     "preset": "crockford",
 
+    "maximumLineLength": {
+        "value": 120,
+        "allowRegex": true,
+        "allowUrlComments": true
+    },
     "disallowQuotedKeysInObjects": null,
     "requireMultipleVarDecl": null,
     "disallowDanglingUnderscores": null


### PR DESCRIPTION
120 characters rule for javascript enforcement